### PR TITLE
No barcode restock

### DIFF
--- a/web/static/internal/apps/restock/index.html
+++ b/web/static/internal/apps/restock/index.html
@@ -9,6 +9,18 @@
   <body>
     <h1>Chez Bob Restock Utility</h1>
     <p>Scan an item to update its information</p>
+    <select id="no_barcode">
+      <option selected disabled>-- No Barcode Item --</option>
+      <script type="module">
+        import menu from "/internal/apps/pos/barcode-menu.js";
+
+        for (let [_, data] of Object.entries(menu)) {
+          for (let [name, details] of Object.entries(data)) {
+            document.getElementById("no_barcode").innerHTML += `<option value='${details.barcode}'>${name}</option>`;
+          }
+        }
+      </script>
+    </select>
     <form id="form"></form>
     <div id="error"></div>
     <script type="module" src="restock.js"></script>

--- a/web/static/internal/apps/restock/restock.js
+++ b/web/static/internal/apps/restock/restock.js
@@ -162,3 +162,4 @@ function report(msg) {
 }
 
 document.getElementById("form").addEventListener("submit", submit);
+document.getElementById("no_barcode").addEventListener("input", (ev) => scan(ev.target.value));


### PR DESCRIPTION
This allows us to use a drop-down to "scan" the no-barcode items. This does not allow adding or removing such items but we can edit the existing ones. Eventually we'll want them to be all dynamic and stored in the DB but for now this will make some things easier.