### PR TITLE
Cutlery in the POS menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run:
 - `npm run setup` (might take a bit, builds sqlite3)
 - `npm run debug` (make sure you have tmux installed)
 
-Open `http://localhost:8080/apps/pos` in the browser.
+Open `http://localhost:8080/internal/apps/pos` in the browser.
 You can manually input barcode values using the barcode panel.
 
 #### Architecture

--- a/web/static/internal/apps/pos/barcode-menu.js
+++ b/web/static/internal/apps/pos/barcode-menu.js
@@ -43,4 +43,10 @@ export default {
       barcode: "411337930531",
     },
   },
+  "Others": {
+    "Cutlery": {
+      defaultCents: 25,
+      barcode: "417645123481",
+    }
+  }
 };


### PR DESCRIPTION
**Problem:** To buy cutlery you need to yoink the whole cutlery box to the POS so it can scan the code on the side.

**How this solves the problem:** You can buy cutlery at the POS as well, without having to bring the whole dispenser over.

**What else was considered:** There used to be a hand-scanner near the cutlery, as well as tea. But there is no hand scanner right now. It's easier to add the cutler to the POS than deploy the hand scanner.

The price, barcode, and name are all the same as prod.