### PR TITLE
Create a popular view at /popular

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -27,4 +27,23 @@ export function user_info() {
     .join("balances", "balances.id", "=", "users.id");
 }
 
+export function item_purchase_info({isoDateFrom, isoDateTo}) {
+  // the isoDates must be a string in the format of YYYY-MM-DD
+  // if no dates are provided, the query will return over all transactions
+  let partialQuery = db("transactions as t")
+    .count('t.item_id', { as: "item_count" })
+    .select(["i.name"])
+    .join("inventory as i", "i.id", "=", "t.item_id");
+  if (isoDateFrom) {
+    partialQuery = partialQuery.where("t.created_at", ">=", isoDateFrom);
+  }
+  if (isoDateTo) {
+    partialQuery = partialQuery.where("t.created_at", "<=", isoDateTo);
+  }
+  return partialQuery
+    .groupBy("t.item_id")
+    .orderBy("item_count", "desc")
+    .limit(20);
+}
+
 export const db = knex(config[DEPLOYMENT_MODE]);

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -10,6 +10,6 @@ tmux split-window;
 tmux send "DEPLOYMENT_MODE='development' RELAY_SERVER=$RELAY_SERVER node inventory" ENTER;
 tmux select-layout main-vertical;
 tmux set -g mouse on;
-tmux set remain-on-exit on
+tmux set remain-on-exit on;
 tmux a;
 

--- a/web/external.js
+++ b/web/external.js
@@ -2,7 +2,7 @@
     external is chezbob's public internet presence.
 */
 
-import { user_info } from "db";
+import { item_purchase_info, user_info } from "db";
 import express from "express";
 import { hybridServer } from "hybrid-http-server";
 
@@ -43,6 +43,35 @@ api.get("/wos/users", async (req, res) => {
     .orderBy("balance")
     .limit(10);
   res.send(users);
+});
+
+/**
+ * GET /popular?from=YYYY-MM-DD&to=YYYY-MM-DD:
+ *  [
+ *    {item_count: int, name: string},
+ *    ...
+ *    <up to 20 items>
+ * ]
+ */
+api.get("/popular", async (req, res) => {
+  // the accepts a `from` and `to` argument, each in YYYY-MM-DD format.
+  const reqFrom = req.query.from;
+  const reqTo = req.query.to;
+  console.log("external.js", reqFrom, reqTo);
+  // Check the format of the dates
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (
+    (reqFrom && !dateRegex.test(reqFrom)) ||
+    (reqTo && !dateRegex.test(reqTo))
+  ) {
+    res.status(400).send("Invalid date format, must be YYYY-MM-DD.");
+    return;
+  }
+  let items = await item_purchase_info({
+    isoDateFrom: reqFrom,
+    isoDateTo: reqTo,
+  });
+  res.send(items);
 });
 
 app.use("/api", api);

--- a/web/static/apps/popular/index.html
+++ b/web/static/apps/popular/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/reset.css" />
+    <link rel="stylesheet" href="/css/terminal.css" />
+    <link rel="stylesheet" href="./popular.css" />
+
+    <title>Chez Bob - What's Popular</title>
+  </head>
+
+  <body>
+    <div id="screen">
+      <!-- slowly moving scanline -->
+      <div class="scanline"></div>
+      <!-- the input and output -->
+      <div id="terminal">
+        <header id="title">What's Popular This Month</header>
+        <br />
+        <div class="glow" id="content"></div>
+      </div>
+    </div>
+    <script type="module" src="./popular.js"></script>
+  </body>
+</html>

--- a/web/static/apps/popular/popular.css
+++ b/web/static/apps/popular/popular.css
@@ -1,0 +1,37 @@
+#title {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    font-size: 48px;
+    text-decoration: underline;
+}
+
+#content {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    font-size: 36px;
+}
+
+tr,
+td {
+    border: 1px solid;
+    padding-left: 30px;
+    padding-right: 30px;
+}
+table td:nth-child(1) {
+    width: 10%;
+    text-align: end;
+}
+
+.balance {
+    border: 1px solid;
+    text-align: center;
+}
+
+#message {
+    text-align: center;
+    font-size: 48px;
+}

--- a/web/static/apps/popular/popular.js
+++ b/web/static/apps/popular/popular.js
@@ -8,9 +8,7 @@ async function displayPopular() {
     let content = document.getElementById("content");
     try {
         let itemsData = await response.json();
-        console.log(itemsData);
         if (itemsData.length == 0) {
-            console.log("No item in the database");
             throw "No item in popular";
         }
         const tableContent = itemsData.map(({item_count, name}) => {

--- a/web/static/apps/popular/popular.js
+++ b/web/static/apps/popular/popular.js
@@ -1,0 +1,42 @@
+const REFRESH_INTERVAL = 60 * 60 * 1000; // One hour in milliseconds
+
+async function displayPopular() {
+    const oneMonthAgo = new Date();
+    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+    const isoDate = oneMonthAgo.toISOString().substring(0,10);
+    let response = await fetch("/api/popular?from=" + isoDate);
+    let content = document.getElementById("content");
+    try {
+        let itemsData = await response.json();
+        console.log(itemsData);
+        if (itemsData.length == 0) {
+            console.log("No item in the database");
+            throw "No item in popular";
+        }
+        const tableContent = itemsData.map(({item_count, name}) => {
+            return (
+                `<tr>
+                    <td>${item_count}</td>
+                    <td>${name}</td>
+                </tr>`);
+        });
+        const tableHeader = `<tr>
+        <th>Times Purchased</th>
+        <th>Item Name</th>
+        </tr>`;
+        const table = `<table>${tableHeader}${tableContent.join("")}</table>`;
+        content.innerHTML = table;
+    } catch (e) {
+        content.innerHTML =
+            `<div id="message">
+            No recent purchases.
+            <br/>
+            Support your local Bob!</div>`;
+    }
+}
+
+// display popular info when loading the page
+displayPopular();
+
+// refresh the wall
+setInterval(displayPopular, REFRESH_INTERVAL); //ms


### PR DESCRIPTION
This creates a new external webview at `/popular`, which shoes the 20 most popular items purchased within the last month.

Its API offers `from` and `to` selections as well. However, with less than a month of real data in the prod-db right now, I haven't made a UI for selecting dates--there's nothing new to see yet.

I could remove the date selection arguments in the DB call if we want. I don't see much harm in leaving it. In fact, it's then an easy PR for a newcomer to add that functionality, esp when we have more historical data.

<img width="1504" alt="Screen Shot 2022-06-09 at 12 54 12 PM" src="https://user-images.githubusercontent.com/1889997/172933304-b99f7799-082e-4e32-ad3b-18de9262683b.png">
