### PR TITLE
Fixed Madeleine spelling

### DIFF
--- a/web/static/internal/apps/pos/barcode-menu.js
+++ b/web/static/internal/apps/pos/barcode-menu.js
@@ -23,7 +23,7 @@ export default {
     },
   },
   "Small Snacks": {
-    "Madeline Cookie": {
+    "Madeleine Cookie": {
       defaultCents: 100,
       barcode: "697941861007",
     },


### PR DESCRIPTION
**Problem:** Madeleine misspelled as _Madeline_ in the "No Barcode" menu. 

**Fixed**: #48 