### PR TITLE
Make content header scrollable.

### DIFF
--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -147,7 +147,7 @@ header button {
 /* style for the title on Bob's mouth */
 #content::before {
   content: "";
-  position: absolute;
+  /* position: absolute; */
   align-self: center;
   transform: translateY(calc(-1.5em - var(--top-padding)));
   display: inline-block;
@@ -160,7 +160,7 @@ header button {
   padding: 0.25em 0.5em;
   text-align: center;
   white-space: nowrap;
-  overflow: hidden;
+  overflow: visible;
 
   background: var(--chez-bg);
   color: var(--bob-color);


### PR DESCRIPTION
The heading now scrolls for pages with the Content title (e.g., -> 'No Barcode Price Check' page title 'Manual Price Check' now scrolls).

Fixes https://github.com/chezbob/chezbob/issues/51