### PR TITLE
Make mouth scroll internally

### DIFF
--- a/web/static/internal/apps/pos/mode.js
+++ b/web/static/internal/apps/pos/mode.js
@@ -16,6 +16,7 @@ class Mode {
   // title;
   // content;
   // hint;
+  // pinScrollToBottom
 
   // The render function is the only routine that updates the DOM. This means our UI is a function
   // from mode to UI.
@@ -41,6 +42,9 @@ class Mode {
     const new_content = this.content;
     if (content.innerHTML != new_content) {
       content.innerHTML = new_content ?? "";
+      if (this.pinScrollToBottom) {
+        content.scrollTop = content.scrollHeight;
+      }
     }
 
     // Set hint
@@ -320,6 +324,7 @@ export class LoggedIn extends Session {
 export class Purchases extends LoggedIn {
   purchases;
   title = "Purchases";
+  pinScrollToBottom = true;
 
   constructor(user, purchases) {
     super(user);
@@ -327,7 +332,7 @@ export class Purchases extends LoggedIn {
   }
 
   get content() {
-    return this.purchases.map(price_row).join("") + this.totals();
+    return this.purchases.map(price_row).join("") + this.totals() + "<div id='scrollAnchor'></div>";
   }
 
   async purchase(item_info) {

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -32,11 +32,11 @@ header button {
 }
 
 #terminal {
-  align-items: center;
+  align-items: stretch;
   display: grid;
   grid-template:
     "header" auto
-    "face" 1fr
+    "face" minmax(0, 1fr)
     "error" auto
     "instructions" 30%
     "footer" 2em / 100%;
@@ -123,14 +123,13 @@ header button {
   display: flex;
   flex-direction: column;
   justify-self: stretch;
-  align-self: center;
+  align-self: stretch;
+  min-height: 0;
 }
 
 #content {
   --top-padding: 2em;
-  overflow: visible;
   padding: var(--top-padding) 1em 1em 1em;
-  flex-grow: 1;
 }
 
 /* Styling for the mouth with no data in it */

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -125,10 +125,12 @@ header button {
   justify-self: stretch;
   align-self: stretch;
   min-height: 0;
+  justify-content: center;
 }
 
 #content {
   --top-padding: 2em;
+  overflow: scroll;
   padding: var(--top-padding) 1em 1em 1em;
 }
 


### PR DESCRIPTION
This change makes the mouth scroll internally when it overflows. It doesn't currently lock the scroll position to the bottom of the mouth though, which it should do. It also de-centers bob's face.