### PR TITLE
Add autocomplete="off" to the POS username input

### DIFF
--- a/web/static/internal/apps/pos/mode.js
+++ b/web/static/internal/apps/pos/mode.js
@@ -407,7 +407,7 @@ class ManualLogin extends DefaultMode {
 
   content = `
         <form onsubmit="window.mode.attemptLogin(event)" style="align-self: center">
-            <input type="text" placeholder="username" name="username" class="glow"><br><br>
+            <input type="text" placeholder="username" name="username" class="glow" autocomplete="off"><br><br>
             <input type="password" placeholder="password" name="password" class="glow"><br><br>
             <button type="submit">Sign In</button>
             <button onclick="window.mode.cancel()" style="float: right">Cancel</button>


### PR DESCRIPTION
@nishant412 (and someone else, not sure their name) noticed that the point-of-sale interface on the kiosk was keeping track of the usernames of people who had (recently?) logged in manually -- so double-tapping on the username text input field would show a dropdown menu of these usernames.

Although Chez Bob's usernames aren't necessarily secret information (since they're also shown publicly on the wall of shame, for example), it would be nice to not show them in such a "convenient" way in the kiosk's dropdown menu. This is mainly because many people don't have passwords set for manual login.

We verified (using the developer console on Firefox on the Chez Bob kiosk) that adding `autocomplete="off"` to the username text `<input>` fixed the problem, and stopped suggesting usernames. Presumably data about recent usernames used to log in are still being stored by Firefox somewhere, but this at least solves the immediate problem.