### PR TITLE
Link to "Welcome to Chez Bob" doc from homepage

### DIFF
--- a/web/static/apps/ah/ah-index.js
+++ b/web/static/apps/ah/ah-index.js
@@ -2,7 +2,7 @@
 // because i forgor how node works
 function onlyShowIfLucky() {
   let r = Math.random(); // in [0, 1)
-  if (r <= 0.2) {
+  if (r <= 0.1) {
     let ahp = document.getElementById("ah");
     ahp.innerHTML = 
         `<a href="apps/ah">Chez Bob's History (real)</a>`;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -22,8 +22,16 @@
           <p>Welcome to Chez Bob!</p>
           <p>Located in CSE 3154.</p>
           <br />
+          <p class="app-link">
+            <a
+              href="https://docs.google.com/document/d/1X_2GpRDKCOCk1UaviOUPUzv0nCcfIsNKN1Xi5QFy36o/edit"
+              >Intro to Chez Bob</a
+            >
+          </p>
           <p class="app-link"><a href="apps/wos">Wall of Shame</a></p>
-          <p class="app-link"><a href="apps/popular">What's Popular This Month</a></p>
+          <p class="app-link">
+            <a href="apps/popular">What's Popular This Month</a>
+          </p>
           <p class="app-link"><a href="history.html">Chez Bob's History</a></p>
           <p class="app-link" id="ah"></p>
         </div>


### PR DESCRIPTION
Adds a link to the ["Welcome to Chez Bob" google doc](https://docs.google.com/document/d/1X_2GpRDKCOCk1UaviOUPUzv0nCcfIsNKN1Xi5QFy36o/edit) from the homepage (https://chezbob.ucsd.edu):

![image](https://github.com/chezbob/chezbob/assets/4177727/4364c95f-8061-4a55-8d6a-dfbd4e3eb737)

This is a much simpler solution than integrating this information into the home page directly -- that could still be done if preferred.