### PR TITLE
Small eye-poking fixes, and fix a minor scanline issue

### DIFF
--- a/web/static/css/terminal.css
+++ b/web/static/css/terminal.css
@@ -55,6 +55,10 @@ body {
   pointer-events: none;
 }
 
+/* Using "pointer-events: none;" here prevents the scanline from "stealing
+ * clicks" from UI items beneath it (e.g. the login button, or poking the POS
+ * face's eyes (lol)). From https://stackoverflow.com/a/32211028.
+ */
 .scanline {
   width: 100%;
   height: 100px;
@@ -69,6 +73,7 @@ body {
   position: absolute;
   bottom: 100%;
   animation: scanline 10s linear infinite;
+  pointer-events: none;
 }
 
 @keyframes scanline {

--- a/web/static/internal/apps/pos/pos-ui.js
+++ b/web/static/internal/apps/pos/pos-ui.js
@@ -6,10 +6,9 @@ const TIME_SPENT_XED_OUT = 1000;
 // The default O character is U+2B24
 const EYE_O = "&#11044;";
 
-// I looked at a lot of X characters until I found something of roughly? the
-// same dimensions as the default O character; the current X character is
-// U+2718. For reference, other good X options include 2716 and 2717.
-const EYE_X = "&#10008;";
+// It's important to pick a character that is supported by the FreeMono font;
+// see the comment above the .eye selector in pos.css for gratuitous details
+const EYE_X = "X";
 
 function openEye(eyeSpan) {
   eyeSpan.innerHTML = EYE_O;

--- a/web/static/internal/apps/pos/pos-ui.js
+++ b/web/static/internal/apps/pos/pos-ui.js
@@ -12,10 +12,12 @@ const EYE_X = "X";
 
 function openEye(eyeSpan) {
   eyeSpan.innerHTML = EYE_O;
+  eyeSpan.classList.remove("pokedeye");
 }
 
 function closeEye(eyeSpan) {
   eyeSpan.innerHTML = EYE_X;
+  eyeSpan.classList.add("pokedeye");
 }
 
 function pokeEye(eyeEvent) {

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -266,6 +266,20 @@ header button {
   font-family: "FreeMono", monospace;
 }
 
+/* An annoying thing about the default eye circle character (U+2B24) is that
+ * it is slightly vertically higher up than an "X" character, even when located
+ * in the same <div>. If you're an insane person who cares about this like me,
+ * the problem can be fixed by adding negative space to the top of poked eye
+ * characters: this hack is from https://stackoverflow.com/a/7612378. (I played
+ * around with negative space values and found that -2px looked best here.)
+ * Thankfully -- as far as I can tell, this doesn't impact the layout of the
+ * rest of the POS interface, regardless of if 0, 1, or 2 eyes are poked.
+ */
+.pokedeye {
+  position: relative;
+  top: -2px;
+}
+
 .eye:first-child {
   margin-right: 0.5em;
 }

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -229,6 +229,32 @@ header button {
 	}
 }
 
+/* By default (going by the #screen font-family orders in terminal.css), the
+ * initial eye characters (U+2B24 -- corresponding to the circles) are of the
+ * family "FreeMono". These circle characters (U+2B24) are not supported in the
+ * first-choice family ("Press Start 2P"), so the next best option is FreeMono.
+ *
+ * In order to make sure that a poked eye has the same dimensions as an unpoked
+ * eye, we force both eyes to use the FreeMono font family. If we don't do
+ * this, then if we poke an eye it could change to a different font family
+ * based on what character we use to represent a poked eye and which font
+ * families support it. Since different font families use different character
+ * sizes, this would make the eye-poking look janky -- e.g. poking the left
+ * eye could adjust the position of the right eye.
+ *
+ * Setting both eyes to use "FreeMono" fixes the problem, so long as the
+ * unpoked and poked eye characters alike are supported by this font family.
+ *
+ * (The old poked-eye character of U+2718 isn't supported by Press Start 2P or
+ * FreeMono, so it would wind up as a "FreeSerif" font family -- and on my
+ * computer this had the same width as a circle in FreeMono, but on the kiosk
+ * it had a slightly different width which looked gross. Using a simple "X"
+ * character fixes the problem.)
+ */
+.eye {
+  font-family: "FreeMono";
+}
+
 .eye:first-child {
   margin-right: 0.5em;
 }

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -274,13 +274,13 @@ header button {
 
 /* An annoying thing about the default eye circle character (U+2B24) is that
  * it is slightly vertically higher up than an "X" character, even when located
- * in the same <div>. (At least, using the FreeMono font.) If, like me, you are
- * an insane person who cares about this for some reason, the problem can be
- * fixed by adding negative space to the top of poked eye characters: this hack
- * is from https://stackoverflow.com/a/7612378. (I played around with negative
- * space values and found that -2px looked best here.) Thankfully -- as far as
- * I can tell, this doesn't impact the layout of the rest of the POS interface,
- * regardless of if 0, 1, or 2 eyes are poked.
+ * in the same <div>. (At least this is the case for the FreeMono font family.)
+ * If, like me, you are an insane person who cares about this for some reason,
+ * the problem can be fixed by adding negative space to the top of poked eye
+ * characters: this hack is from https://stackoverflow.com/a/7612378. (I played
+ * around with negative space values and found that -2px looked best here.)
+ * Thankfully -- as far as I can tell, this doesn't impact the layout of the
+ * rest of the POS interface, regardless of if 0, 1, or 2 eyes are poked.
  */
 .pokedeye {
   position: relative;

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -244,12 +244,16 @@ header button {
  *
  * Setting both eyes to use "FreeMono" fixes the problem, so long as the
  * unpoked and poked eye characters alike are supported by this font family.
+ * (And so long as FreeMono is available on the system running the POS -- but
+ * this shouldn't be an issue, since I think GNU FreeFont is packaged with
+ * all modern? Ubuntu versions.)
  *
  * (The old poked-eye character of U+2718 isn't supported by Press Start 2P or
- * FreeMono, so it would wind up as a "FreeSerif" font family -- and on my
+ * FreeMono, so it would wind up as a "FreeSerif" font family -- on my
  * computer this had the same width as a circle in FreeMono, but on the kiosk
- * it had a slightly different width which looked gross. Using a simple "X"
- * character fixes the problem.)
+ * it had a slightly different width which made poking look janky. Using a
+ * simple "X" character fixes the problem, since "X" is ofc supported by
+ * FreeMono.)
  */
 .eye {
   font-family: "FreeMono";

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -274,12 +274,13 @@ header button {
 
 /* An annoying thing about the default eye circle character (U+2B24) is that
  * it is slightly vertically higher up than an "X" character, even when located
- * in the same <div>. If you're an insane person who cares about this like me,
- * the problem can be fixed by adding negative space to the top of poked eye
- * characters: this hack is from https://stackoverflow.com/a/7612378. (I played
- * around with negative space values and found that -2px looked best here.)
- * Thankfully -- as far as I can tell, this doesn't impact the layout of the
- * rest of the POS interface, regardless of if 0, 1, or 2 eyes are poked.
+ * in the same <div>. (At least, using the FreeMono font.) If, like me, you are
+ * an insane person who cares about this for some reason, the problem can be
+ * fixed by adding negative space to the top of poked eye characters: this hack
+ * is from https://stackoverflow.com/a/7612378. (I played around with negative
+ * space values and found that -2px looked best here.) Thankfully -- as far as
+ * I can tell, this doesn't impact the layout of the rest of the POS interface,
+ * regardless of if 0, 1, or 2 eyes are poked.
  */
 .pokedeye {
   position: relative;

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -234,7 +234,7 @@ header button {
  * family "FreeMono". These circle characters (U+2B24) are not supported in the
  * first-choice family ("Press Start 2P"), so the next best option is FreeMono.
  *
- * In order to make sure that a poked eye has the same dimensions as an unpoked
+ * In order to make sure that a poked eye has the same width as an unpoked
  * eye, we force both eyes to first try to use the FreeMono font family. If we
  * don't do this, then if we poke an eye it could change to a different font
  * family based on what character we use to represent a poked eye and which font
@@ -249,9 +249,9 @@ header button {
  * the poked-eye character is also supported by this font family. (This is why
  * we changed the "X" character from U+2718 to just "X", since FreeMono doesn't
  * support U+2718. The backup font family used for U+2718 had the same
- * dimensions on my laptop but slightly different dimensions on the kiosk,
- * resulting in poking looking janky on the kiosk. If you're still reading
- * this comment like three paragraphs in, I am so sorry.)
+ * width on my laptop but a slightly different width on the kiosk, resulting
+ * in poking looking janky on the kiosk. If you're still reading this comment
+ * like three paragraphs in, I am so sorry.)
  *
  * FreeMono is part of the GNU FreeFont package, I think, and GNU FreeFont is
  * packaged with all modern (?) Ubuntu versions -- so FreeMono should always be

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -235,28 +235,35 @@ header button {
  * first-choice family ("Press Start 2P"), so the next best option is FreeMono.
  *
  * In order to make sure that a poked eye has the same dimensions as an unpoked
- * eye, we force both eyes to use the FreeMono font family. If we don't do
- * this, then if we poke an eye it could change to a different font family
- * based on what character we use to represent a poked eye and which font
+ * eye, we force both eyes to first try to use the FreeMono font family. If we
+ * don't do this, then if we poke an eye it could change to a different font
+ * family based on what character we use to represent a poked eye and which font
  * families support it. Since different font families use different character
  * sizes, this would make the eye-poking look janky -- e.g. poking the left
- * eye could adjust the position of the right eye.
+ * eye could lead to the new left eye character being slightly thinner or wider
+ * than the default eye character, which would adjust the position of the right
+ * eye.
  *
- * Setting both eyes to use "FreeMono" fixes the problem, so long as the
- * unpoked and poked eye characters alike are supported by this font family.
- * (And so long as FreeMono is available on the system running the POS -- but
- * this shouldn't be an issue, since I think GNU FreeFont is packaged with
- * all modern? Ubuntu versions.)
+ * Since "FreeMono" supports the default eye circle character (U+2B24), setting
+ * it as our "first choice" font family here fixes the problem -- so long as
+ * the poked-eye character is also supported by this font family. (This is why
+ * we changed the "X" character from U+2718 to just "X", since FreeMono doesn't
+ * support U+2718. The backup font family used for U+2718 had the same
+ * dimensions on my laptop but slightly different dimensions on the kiosk,
+ * resulting in poking looking janky on the kiosk. If you're still reading
+ * this comment like three paragraphs in, I am so sorry.)
  *
- * (The old poked-eye character of U+2718 isn't supported by Press Start 2P or
- * FreeMono, so it would wind up as a "FreeSerif" font family -- on my
- * computer this had the same width as a circle in FreeMono, but on the kiosk
- * it had a slightly different width which made poking look janky. Using a
- * simple "X" character fixes the problem, since "X" is ofc supported by
- * FreeMono.)
+ * FreeMono is part of the GNU FreeFont package, I think, and GNU FreeFont is
+ * packaged with all modern (?) Ubuntu versions -- so FreeMono should always be
+ * available on the kiosk, provided we don't decide to like port over the kiosk
+ * system to Windows or something. In the event that FreeMono isn't available,
+ * we'll just default to whatever monospace font is available -- this might
+ * make poking look janky again if the monospace font doesn't support U+2B24 or
+ * has differently-sized characters for some reason, but this problem probably
+ * won't ever come up.
  */
 .eye {
-  font-family: "FreeMono";
+  font-family: "FreeMono", monospace;
 }
 
 .eye:first-child {

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -188,48 +188,10 @@ header button {
   font-size: 48px;
 }
 
-/* Blinking notes: The animation-duration is actually half of the total
- * amount of time taken between blinks.
- *
- * - When you refresh the POS page, there will be DURATION seconds until the
- *   first blink.
- * - Then there will be another DURATION seconds, which is begun by
- *   the eyes "un-blinking" (returning to normal). This is due, I think, to the
- *   animation-direction being set to "alternate".
- * - Then there will be another DURATION seconds, at the end of which the eyes
- *   blink.
- *
- * So the animation-duration being 30 seconds implies that each state (about to
- * blink, or recovering from un-blinking) takes 30 seconds -- but the total
- * time between consecutive blinks is ~60 seconds.
- */
-#eyes {
-  text-align: center;
-  color: var(--bob-color);
-  transition: color 200ms linear;
-  font-size: 96px;
-  min-width: 4em;
-  margin-bottom: 80px;
-  transform-origin: 50% 75%;
-  animation-name: blinkeyes;
-  animation-duration: 30s;
-  animation-direction: alternate;
-  animation-iteration-count: infinite;
-}
-
-@keyframes blinkeyes {
-	from {
-		transform: scaleY(1.0);
-	}
-	99% {
-		transform: scaleY(1.0);
-	}
-	to {
-		transform: scaleY(0.1);
-	}
-}
-
-/* By default (going by the #screen font-family orders in terminal.css), the
+/************
+ * FONT NOTES
+ ************
+ * By default (going by the #screen font-family orders in terminal.css), the
  * initial eye characters (U+2B24 -- corresponding to the circles) are of the
  * family "FreeMono". These circle characters (U+2B24) are not supported in the
  * first-choice family ("Press Start 2P"), so the next best option is FreeMono.
@@ -261,9 +223,53 @@ header button {
  * make poking look janky again if the monospace font doesn't support U+2B24 or
  * has differently-sized characters for some reason, but this problem probably
  * won't ever come up.
+ *
+ * ^^^ Yeah, all of that text was with regards to the single line setting the
+ * font-family of this div. CSS is hard :(
+ *
+ ****************
+ * BLINKING NOTES
+ ****************
+ * The animation-duration is actually half of the total
+ * amount of time taken between blinks.
+ *
+ * - When you refresh the POS page, there will be DURATION seconds until the
+ *   first blink.
+ * - Then there will be another DURATION seconds, which is begun by
+ *   the eyes "un-blinking" (returning to normal). This is due, I think, to the
+ *   animation-direction being set to "alternate".
+ * - Then there will be another DURATION seconds, at the end of which the eyes
+ *   blink.
+ *
+ * So the animation-duration being 30 seconds implies that each state (about to
+ * blink, or recovering from un-blinking) takes 30 seconds -- but the total
+ * time between consecutive blinks is ~60 seconds.
  */
-.eye {
+#eyes {
   font-family: "FreeMono", monospace;
+  text-align: center;
+  color: var(--bob-color);
+  transition: color 200ms linear;
+  font-size: 96px;
+  min-width: 4em;
+  margin-bottom: 80px;
+  transform-origin: 50% 75%;
+  animation-name: blinkeyes;
+  animation-duration: 30s;
+  animation-direction: alternate;
+  animation-iteration-count: infinite;
+}
+
+@keyframes blinkeyes {
+	from {
+		transform: scaleY(1.0);
+	}
+	99% {
+		transform: scaleY(1.0);
+	}
+	to {
+		transform: scaleY(0.1);
+	}
 }
 
 /* An annoying thing about the default eye circle character (U+2B24) is that


### PR DESCRIPTION
- Changes the poked-eye character from `✘` to `X`, which -- combined with forcing the eyes to use a consistent font family (`"FreeMono"`, or `monospace` if that's unavailable) -- makes sure that poking doesn't change the widths of the eye characters.
  - The comments labeled `FONT NOTES` in the `pos.css` file explain the problem and solution in detail, but the tldr is that getting unicode characters and fonts consistent across systems is challenging. The initial implementation of this looked fine on my laptop, but a bit janky on the kiosk -- this patch should make the kiosk look less janky.

  - To make sure that eyes look vertically centered whether poked or unpoked (and thus make sure that the face looks good even if only one eye is poked), I also added some extra CSS (in the `pokedeye` class) that slightly adjusts the vertical position of poked eyes to make the transition look smooth. (Without this extra CSS, the top of the `X` character is a few pixels below the top of the `⬤` character; as far as I can tell, this is due to the default positioning of characters in the font we're using.)

  - The row of eyes is now positioned slightly higher up on the page than before. I didn't make this change intentionally; I think it is a side effect of using the correct font family (`FreeMono`) from the start, rather than trying to render the `⬤` characters with the "first choice" font family of `Press Start 2P` (which doesn't support `⬤` characters).
    - Explanation: since `Press Start 2P`'s characters are bigger than `FreeMono`'s (in general, and to my knowledge), I think the old code's CSS results in the browser computing an unnecessarily-large bounding box for these characters, which pushes them down a bit on the page.
    - This probs doesn't matter (I didn't even notice it at first), but I figured I should document it here for the sake of transparency.  

- While testing the above fixes in unnecessary detail, I noticed that the scanline could "steal" clicks from UI elements beneath it -- this could actually happen in practice (if you've ever had to press on a button on the kiosk twice in order to get it to do something, this might be why?). I adjusted the scanline CSS to fix this issue.

(Static) screenshot of what poking looks like now:

![image](https://github.com/chezbob/chezbob/assets/4177727/fb8fa6da-d469-49a8-b663-a2b38ea679e9)

sorry this is so unnecessarily detailed lol