### PR TITLE
Make the POS colors go through a rainbow gradient sometimes

### DIFF
--- a/web/static/css/terminal.css
+++ b/web/static/css/terminal.css
@@ -10,6 +10,7 @@ html {
   --chez-blue: aqua;
   --chez-bg: #222222;
   --chez-green: lime;
+  --chez-yellow: rgb(255, 255, 73);
   --chez-purple: rgb(255, 73, 255);
   --chez-red: rgb(255, 70, 101);
   --bob-color: var(--chez-blue);

--- a/web/static/internal/apps/pos/mode.js
+++ b/web/static/internal/apps/pos/mode.js
@@ -60,6 +60,21 @@ class Mode {
     if (error.innerHTML != new_error) {
       error.innerHTML = new_error;
     }
+
+    // during June, and/or from 6-7 am/pm, use rainbow colors
+    var currDate = new Date();
+    var inJune = currDate.getMonth() === 5;
+    var hr = currDate.getHours();
+    var eles = document.querySelectorAll(".eye, #content, #content::before")
+    if (inJune || hr === 6 || hr === 18) {
+      eles.forEach(function (e) {
+          e.classList.add("rainbow");
+      });
+    } else {
+      eles.forEach(function (e) {
+          e.classList.remove("rainbow");
+      });
+    }
   }
 
   /**

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -281,51 +281,51 @@ header button {
 }
 
 @keyframes rainbowanim {
-    /* "color" is for the eyes; "border-color" is for the mouth;
-     * "--line-color" is for the box shadow glow on the mouth.
-     */
-	from {
-        color: var(--chez-blue);
-        border-color: var(--chez-blue);
-        --line-color: var(--chez-blue);
-	}
-	20% {
-        color: var(--chez-purple);
-        border-color: var(--chez-purple);
-        --line-color: var(--chez-purple);
-	}
-	40% {
-        color: var(--chez-red);
-        border-color: var(--chez-red);
-        --line-color: var(--chez-red);
-	}
-	60% {
-        color: var(--chez-yellow);
-        border-color: var(--chez-yellow);
-        --line-color: var(--chez-yellow);
-	}
-	80% {
-        color: var(--chez-green);
-        border-color: var(--chez-green);
-        --line-color: var(--chez-green);
-	}
-	to {
-        color: var(--chez-blue);
-        border-color: var(--chez-blue);
-        --line-color: var(--chez-blue);
-	}
+  /* "color" is for the eyes; "border-color" is for the mouth;
+   * "--line-color" is for the box shadow glow on the mouth.
+   */
+  from {
+    color: var(--chez-blue);
+    border-color: var(--chez-blue);
+    --line-color: var(--chez-blue);
+  }
+  20% {
+    color: var(--chez-purple);
+    border-color: var(--chez-purple);
+    --line-color: var(--chez-purple);
+  }
+  40% {
+    color: var(--chez-red);
+    border-color: var(--chez-red);
+    --line-color: var(--chez-red);
+  }
+  60% {
+    color: var(--chez-yellow);
+    border-color: var(--chez-yellow);
+    --line-color: var(--chez-yellow);
+  }
+  80% {
+    color: var(--chez-green);
+    border-color: var(--chez-green);
+    --line-color: var(--chez-green);
+  }
+  to {
+    color: var(--chez-blue);
+    border-color: var(--chez-blue);
+    --line-color: var(--chez-blue);
+  }
 }
 
 @keyframes blinkeyes {
-	from {
-		transform: scaleY(1.0);
-	}
-	99% {
-		transform: scaleY(1.0);
-	}
-	to {
-		transform: scaleY(0.1);
-	}
+  from {
+    transform: scaleY(1.0);
+  }
+  99% {
+    transform: scaleY(1.0);
+  }
+  to {
+    transform: scaleY(0.1);
+  }
 }
 
 /* An annoying thing about the default eye circle character (U+2B24) is that

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -260,6 +260,60 @@ header button {
   animation-iteration-count: infinite;
 }
 
+.rainbow {
+  animation-name: rainbowanim;
+  animation-duration: 20s;
+  animation-direction: normal;
+  animation-iteration-count: infinite;
+}
+
+#content.rainbow::before {
+  /* apply the rainbow animation the title on the mouth, also. we can't add
+   * classes to "pseudoelements" like ::before, but it is sufficient to hackily
+   * just add the elements from .rainbow to #content.rainbow::before
+   */
+  animation-name: rainbowanim;
+  animation-duration: 20s;
+  animation-direction: normal;
+  animation-iteration-count: infinite;
+}
+
+@keyframes rainbowanim {
+    /* "color" is for the eyes; "border-color" is for the mouth;
+     * "--line-color" is for the box shadow glow on the mouth.
+     */
+	from {
+        color: var(--chez-blue);
+        border-color: var(--chez-blue);
+        --line-color: var(--chez-blue);
+	}
+	20% {
+        color: var(--chez-purple);
+        border-color: var(--chez-purple);
+        --line-color: var(--chez-purple);
+	}
+	40% {
+        color: var(--chez-red);
+        border-color: var(--chez-red);
+        --line-color: var(--chez-red);
+	}
+	60% {
+        color: var(--chez-yellow);
+        border-color: var(--chez-yellow);
+        --line-color: var(--chez-yellow);
+	}
+	80% {
+        color: var(--chez-green);
+        border-color: var(--chez-green);
+        --line-color: var(--chez-green);
+	}
+	to {
+        color: var(--chez-blue);
+        border-color: var(--chez-blue);
+        --line-color: var(--chez-blue);
+	}
+}
+
 @keyframes blinkeyes {
 	from {
 		transform: scaleY(1.0);

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -268,9 +268,11 @@ header button {
 }
 
 #content.rainbow::before {
-  /* apply the rainbow animation the title on the mouth, also. we can't add
-   * classes to "pseudoelements" like ::before, but it is sufficient to hackily
-   * just add the elements from .rainbow to #content.rainbow::before
+  /* Apply the rainbow animation to the title on the mouth (#content::before).
+   * Ideally, we'd just add the .rainbow class to #content::before, but we
+   * can't add classes to "pseudoelements" like ::before. As a hacky workaround
+   * we can just add everything in .rainbow to #content::before when #content
+   * has the .rainbow class. (there is probs a more elegant way to do this tho)
    */
   animation-name: rainbowanim;
   animation-duration: 20s;


### PR DESCRIPTION
During June (and also from 6-7 am / pm outside of June), the eye / mouth colors and UI will cycle through a rainbow gradient. This is useful probably

![Peek 2024-11-15 16-55](https://github.com/user-attachments/assets/1eb88238-1be3-4adf-8954-8f4312b9b49a)

Notes:

- As shown in the GIF, certain text elements (e.g. `<h1>`s that show up in the mouth box triggered by `Help`) do not change color. This could be adjusted, but I think maintaining contrast actually helps with readability.

- The gradient colors / timing were kind of arbitrarily selected, so if you prefer a different rainbow that can be fixed easily

- I haven't tested how this behaves when the UI is in the "logged-in" state, since I'm not sure how/if to simulate that in the test deployment. It should probably be fine though