### PR TITLE
Changed the pinScrollToBottom to false

### DIFF
--- a/inventory/inventory.js
+++ b/inventory/inventory.js
@@ -141,6 +141,7 @@ inventory.handle("login", async (attempt) => {
   }
 
   let users = await db("users").where({ username }).limit(1);
+  users
   if (users.length !== 1) {
     throw new Error("Invalid username/password");
   }

--- a/web/static/internal/apps/pos/barcode-menu.js
+++ b/web/static/internal/apps/pos/barcode-menu.js
@@ -13,7 +13,7 @@ export default {
       defaultCents: 100,
       barcode: "488348702402",
     },
-    Espresso: {
+    "Espresso": {
       defaultCents: 150,
       barcode: "845183001266",
     },

--- a/web/static/internal/apps/pos/mode.js
+++ b/web/static/internal/apps/pos/mode.js
@@ -339,7 +339,7 @@ export class LoggedIn extends Session {
 export class Purchases extends LoggedIn {
   purchases;
   title = "Purchases";
-  pinScrollToBottom = true;
+  pinScrollToBottom = false;
 
   constructor(user, purchases) {
     super(user);


### PR DESCRIPTION
There was a class called ManualPurchase which extends Purchases that has a variable named pinScrollToBottom set to true. This was causing the list to always point to the last element in the list. This was not the case with nobarcodepricecheck which we do without logging in since it extends the direct parent Session that doesn't have this variable.

set it to false to fix it.