### PR TITLE
Truncate long item names, shorten datetime format

### DIFF
--- a/web/static/internal/apps/pos/mode.js
+++ b/web/static/internal/apps/pos/mode.js
@@ -658,8 +658,11 @@ class ViewTransactions extends ManageAccount {
     signDisplay: "exceptZero",
   });
   static #dateFormat = new Intl.DateTimeFormat("en-US", {
-    dateStyle: "short",
-    timeStyle: "short",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
   });
 
   title = `View Transactions`;
@@ -681,9 +684,9 @@ class ViewTransactions extends ManageAccount {
                   ${name ?? ""}
                 </div>
                 <div class="dots"></div>
-                <div class="price-cost">${ViewTransactions.#dateFormat.format(
-                  new Date(created_at)
-                )}</div>
+                <div class="price-cost">${ViewTransactions.#dateFormat
+                  .format(new Date(created_at))
+                  .replace(",", "")}</div>
               </div>
             `
           )

--- a/web/static/internal/apps/pos/mode.js
+++ b/web/static/internal/apps/pos/mode.js
@@ -65,14 +65,14 @@ class Mode {
     var currDate = new Date();
     var inJune = currDate.getMonth() === 5;
     var hr = currDate.getHours();
-    var eles = document.querySelectorAll(".eye, #content, #content::before")
+    var eles = document.querySelectorAll(".eye, #content, #content::before");
     if (inJune || hr === 6 || hr === 18) {
       eles.forEach(function (e) {
-          e.classList.add("rainbow");
+        e.classList.add("rainbow");
       });
     } else {
       eles.forEach(function (e) {
-          e.classList.remove("rainbow");
+        e.classList.remove("rainbow");
       });
     }
   }
@@ -700,7 +700,7 @@ class ViewTransactions extends ManageAccount {
                 </div>
                 <div class="dots"></div>
                 <div class="price-cost">${ViewTransactions.#dateFormat
-                  .format(new Date(created_at))
+                  .format(new Date(created_at.replace(" ", "T") + "Z"))
                   .replace(",", "")}</div>
               </div>
             `

--- a/web/static/internal/apps/pos/pos.css
+++ b/web/static/internal/apps/pos/pos.css
@@ -99,8 +99,14 @@ header button {
   white-space: nowrap;
 }
 
-.dots {
+.price-row > .price-name {
   flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dots {
+  flex: 1 0 0;
   overflow: hidden;
   text-overflow: "";
 }
@@ -261,15 +267,15 @@ header button {
 }
 
 @keyframes blinkeyes {
-	from {
-		transform: scaleY(1.0);
-	}
-	99% {
-		transform: scaleY(1.0);
-	}
-	to {
-		transform: scaleY(0.1);
-	}
+  from {
+    transform: scaleY(1);
+  }
+  99% {
+    transform: scaleY(1);
+  }
+  to {
+    transform: scaleY(0.1);
+  }
 }
 
 /* An annoying thing about the default eye circle character (U+2B24) is that


### PR DESCRIPTION
Fixes #92 

![image](https://github.com/user-attachments/assets/a6acc840-0b49-4945-806a-89fd60a9c70f)

- Shortened the date format from `M/D/YY, H:MM PM` to `M/D HH:MM` (removed year, comma; switched to 24-hour time)
- For all price lists, the price name will be truncated with ellipses if it is too long