### PR TITLE
Launch external page in npm debug script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Install node v17 with npm. For development I recommend using nvm, but for
 deployment you should use official packages (since nvm just installs for the user)
 
 Docker:
-
-`docker run --rm -p 8080:8080 -it ttkarve/chezbob npm run debug`
+```sh
+docker build -t chezbob .
+docker run --rm -p 8080:8080 -p 8081:8081 -it chezbob npm run debug
+```
 
 Run manually:
 
 - `npm run setup` (might take a bit, builds sqlite3)
 - `npm run debug` (make sure you have tmux installed)
 
-Open `http://localhost:8080/internal/apps/pos` in the browser.
+Open `http://localhost:8080/internal/apps/pos` in the browser to view the internal page and `http://localhost:8081` to view the external, public facing page.
 You can manually input barcode values using the barcode panel.
 
 #### Architecture

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -3,6 +3,8 @@ export DEBUG=true;
 export RELAY_SERVER='ws://localhost:8080/'
 tmux new-session -d -s chezbob "DEPLOYMENT_MODE='development' HTTP_PORT=8080 node web/internal.js";
 tmux split-window;
+tmux send "DEPLOYMENT_MODE='development' HTTP_PORT=8081 node web/external.js" ENTER;
+tmux split-window;
 tmux send "SERVICE_IDENT='barcode' DESTINATION_IDENT='pos' RELAY_SERVER=$RELAY_SERVER node scripts/debug_barcode" ENTER;
 tmux split-window;
 tmux send "SERVICE_IDENT='cash' DESTINATION_IDENT='pos' RELAY_SERVER=$RELAY_SERVER node scripts/debug_cash" ENTER;
@@ -12,4 +14,3 @@ tmux select-layout main-vertical;
 tmux set -g mouse on;
 tmux set remain-on-exit on;
 tmux a;
-


### PR DESCRIPTION
Add `web/external.js` to the npm debug script for debugging frontend changes, because currently the script only deploys the internal page. The frontend can be viewed locally at port 8081.

I'm making a PR for this because I'm trying to fix some other frontend issues and this would make it easier for me and other contributors to debug the frontend.

I also updated the README to add the correct Docker commands. I opted to remove the existing `docker run --rm -p 8080:8080 -it ttkarve/chezbob npm run debug` command from the README because that Docker hub image only works for ARM64 systems; it's more straightforward and flexible to just build the Docker image yourself.