### PR TITLE
Add toggle for more readable/accessible monospace font

### DIFF
--- a/web/static/apps/popular/index.html
+++ b/web/static/apps/popular/index.html
@@ -18,11 +18,12 @@
       <div class="scanline"></div>
       <!-- the input and output -->
       <div id="terminal">
-        <header class="main-title">What's Popular This Month</header>
+        <header class="main-title">What's Popular<br>This Month</header>
         <br />
         <div class="glow" id="content"></div>
       </div>
     </div>
     <script type="module" src="./popular.js"></script>
+    <script src="/js/font-toggle.js"></script>
   </body>
 </html>

--- a/web/static/apps/wos/index.html
+++ b/web/static/apps/wos/index.html
@@ -26,5 +26,6 @@
       </div>
     </div>
     <script type="module" src="./wos.js"></script>
+    <script src="/js/font-toggle.js"></script>
   </body>
 </html>

--- a/web/static/css/terminal.css
+++ b/web/static/css/terminal.css
@@ -27,6 +27,7 @@ body {
 
 #screen {
   overflow: auto;
+  position: relative;
   background: var(--chez-bg);
   font-family: "Press Start 2P", "FreeMono", monospace;
   color: white;
@@ -131,6 +132,29 @@ a:link {
 
 a:hover {
   color: #ae59eb;
+}
+
+body.accessible-font #screen {
+  font-family: "FreeMono", monospace;
+  text-shadow: none;
+}
+
+body.accessible-font .scanline {
+  display: none;
+}
+
+#font-toggle-btn {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  font-size: 14px;
+  margin: 0;
+  z-index: 10;
+  opacity: 0.8;
+}
+
+#font-toggle-btn:hover {
+  opacity: 1;
 }
 
 /* Adapted from what was originally the "#title" selector in the WOS CSS */

--- a/web/static/faq.html
+++ b/web/static/faq.html
@@ -57,12 +57,12 @@
                 <li><a href="#snacks">Snacks</a></li>
                 <li><a href="#misc">Misc.</a></li>
             </ul>
-        
+
             <h2 id="general" style="margin-top: 20px;">General</h2>
 
                 <h3>What is Chez Bob?</h3>
                 <p>Chez Bob (pronounced 'SHAY bob', or if you're a word nerd, /ʃeɪ bɑb/) is a 24/7, fully student- and volunteer-run snack and coffee co-op. We purchase snacks from Costco and sell them to graduate students, faculty, and staff. Chez Bob works like a bank. Users have accounts with balances. You pay by scanning what you take, which deducts from your balance. You can make deposits with cash at the kiosk.</p>
-           
+
                 <h3>What does Chez Bob offer?</h3>
                 <p>Chez Bob sells the following items:</p>
                 <ul>
@@ -79,10 +79,10 @@
                     <li>Workspaces with tabletop outlets</li>
                     <li>Board games (to borrow)</li>
                 </ul>
-                 
+
                 <h3 id="espresso">How does the espresso machine work?</h3>
                 <p>In order to use the espresso machine, you first need to be trained to ensure you know how to operate it properly. For the current training times, please reach out to whoever is listed as the "Espresso Executive" on the <a href="./team.html">team page</a>.</p>
-                
+
                 <h3>I heard there was free food 👀?</h3>
                 <p>People often leave any leftover food from events on the counter in Chez Bob, so check the #chezbob channel in the CSE Slack for any free food announcements! If you're not part of the CSE slack, please email <a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a> to be added.</p>
 
@@ -90,7 +90,7 @@
                 <p>Please either send a message in the #chezbob channel in the CSE Slack, or send us an email at <a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a>.</p>
 
             <h2 id="accounts">Accounts</h2>
-            
+
                 <h3 id="eligibility">Who can get a Chez Bob account?</h3>
                 <p>The following CSE members are eligible for Chez Bob accounts:</p>
                 <ul>
@@ -99,16 +99,16 @@
                     <li>Faculty</li>
                     <li>Staff</li>
                     <li>Students doing research with CSE faculty</li>
-                </ul> 
+                </ul>
                 <p>Overall, in order to get a Chez Bob account you need to have a CSE faculty member who can take responsibility for you, so we have someone to contact should any issues arise (e.g. excessive debt, stealing, otherwise misusing Chez Bob). This means that in general, undergraduate students are not eligible for Chez Bob accounts. The only exceptions to this are undergraduates doing research with a CSE faculty member, or undergraduates tutoring/TAing for a CSE faculty member. In those cases, you will only have access to Chez Bob while you still hold that position (i.e. if you only tutor for one quarter, your Chez Bob access would end at the end of that quarter).</p>
 
                 <h3 id="new-acct">How do I get a Chez Bob account?</h3>
                 <p>First, <a href="#eligibility">make sure you are eligible</a> for a Chez Bob account. Second, <a href="#existing-acct">make sure you don't already have a Chez Bob account</a>-- we automatically create new accounts for incoming grad students, faculty, and staff every fall. If you are eligible for an account and don't already have one, then please email <a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a> with your name, UCSD email, and CSE affiliation (grad student, faculty, etc). If you are an undergraduate, please also CC the advisor who can "vouch" for you (your research advisor or the faculty member for the class you tutor).</p>
-                
+
                 <h3>Why do you have to manually create accounts, why can't they just be created automatically?</h3>
                 <p>We want to make sure that all Chez Bob members can be contacted in case of any account issues, security advisories, excessive debt, etc. This means that we need to check that everyone requesting an account is a UCSD and CSE affiliate, and has (or is) a CSE faculty member who can be contacted if we need to escalate an issue.</p>
 
-                <h3 id="existing-acct">How do I check if I already have a Chez Bob account?</h3> 
+                <h3 id="existing-acct">How do I check if I already have a Chez Bob account?</h3>
                 <p>Go into Chez Bob (CSE 3154) and click the "Manual Login" button. Try using the first half of your UCSD email (e.g. 'chezbob' if your UCSD email is 'chezbob@ucsd.edu') and a blank password to log in. If that works, congrats! You have an existing Chez Bob account. If not, please <a href="#new-acct">request an account</a>.</p>
 
                 <h3>How do I add an NFC login card?</h3>
@@ -118,13 +118,13 @@
                 <p>First, log into your account on the kiosk. Then click the "Account Management" button, and then the "Change Password" button. From there you should be able to enter your old and new password.</p>
 
                 <h3>How do I reset my password? I forgot :(</h3>
-                <p>Please email us at <a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a> and we can reset your password.</p> 
-            
+                <p>Please email us at <a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a> and we can reset your password.</p>
+
             <h2 id="debt">Debt</h2>
 
                 <h3>Can I go into debt?</h3>
                 <p>Yes, you are allowed to have a negative balance (go into debt) on your Chez Bob account. The reasoning behind it is we'd rather have people accrue debts that they can pay later, rather than have people stealing snacks/drinks because they really want the snack now but don't have cash on them. However, there are rules for how much debt you're allowed to carry (see below).</p>
-                
+
                 <h3>How much debt can I carry?/What are the rules about paying it back?</h3>
                 <p>Debt should be kept under $20.</p>
                 <ul>
@@ -154,16 +154,16 @@
                         </ul>
                 </ul>
                 <p>We will check debts every Monday and the first Monday you are over $20/$40 of debt will be the starting day for counting how many weeks your debt is over $20/$40. Mondays will also be the day that the punishment is enacted-- e.g. if Monday the 1st is the first Monday your debt is over $20, on Monday the 8th (a week later), you will receive an angry email and be shamed in Slack.</p>
-                
+
                 <h3>How do I pay my debt back?</h3>
                 <p>Log into the kiosk in Chez Bob, and insert cash into the bill acceptor while logged in to add money to your account. If you have been locked out of Chez Bob for excessive debt, you will have to contact one of the Chez Bob admins to let you in so you can pay your debt (contact info <a href="./team.html">here</a>).</p>
-                
+
                 <h3>How do I pay my debt back if I'm no longer in San Diego/I've graduated/some other unique circumstance?</h3>
                 <p>You still are responsible for paying your debt even if you graduate or otherwise leave San Diego/UCSD. Please email us at <a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a> and we can figure out a solution for your individual situation.</p>
-                
-                
+
+
             <h2 id="volunteering">Volunteering</h2>
-                
+
                 <h3>How can I help out with Chez Bob?</h3>
                 <p>Glad you asked! Since Chez Bob is entirely volunteer-run, there are lots of ways to help, including:</p>
                 <ul>
@@ -178,7 +178,7 @@
                 <p>If you're interested in volunteering or have an idea for Chez Bob, please join the #chezbob-volunteers channel in the CSE Slack for more information.</p>
 
                 <h3>Are there any requirements for volunteering?</h3>
-                <p>There's no binding commitment or required number of hours to volunteer, we're pretty flexible since we know volunteers are also busy graduate students :). It's totally cool if you need to take a few weeks off of volunteering to work on a paper deadline or attend a conference, for example. If you can't volunteer on a regular basis, you can still help out with one-off tasks (unloading a Costco order, fixing the TV in Chez Bob, etc.) or take part in our quarterly hackathons that we announce in Slack. 
+                <p>There's no binding commitment or required number of hours to volunteer, we're pretty flexible since we know volunteers are also busy graduate students :). It's totally cool if you need to take a few weeks off of volunteering to work on a paper deadline or attend a conference, for example. If you can't volunteer on a regular basis, you can still help out with one-off tasks (unloading a Costco order, fixing the TV in Chez Bob, etc.) or take part in our quarterly hackathons that we announce in Slack.
 
                 <h3>I have an idea for contributing to Chez Bob, how can I make it happen?</h3>
                 <p>If you have a new idea for Chez Bob, silly or serious, we're totally willing to try it out as long as you're willing to be responsible for it! In the past, students have taken charge of things like ordering specialty snacks/drinks that Costco doesn't carry, setting up collaborations with the Food Recovery Network to deliver more leftover food, upgrading and refurbishing the pool table, and more. Depending on the idea, we can also provide some funding (i.e. like paying to refelt the pool table).</p>
@@ -203,27 +203,28 @@
                     <li>Enough people need to "want" the item, so we can be reasonably sure that everything we order will get sold (you could for example ask in Slack for people to emoji-react if they'd also like this item stocked)</li>
                     <li>If the item doesn't sell, we probably won't order it again (or at least we'll wait a few months before ordering again)</li>
                 </ul>
-                
+
                 <h3>Can you stock this &lt;snack/drink/other item&gt; that Costco Business does not carry?</h3>
                 <p>If you want us to stock a specific item that Costco doesn't sell, as long as you are willing to be in charge of ordering it and bringing it into Chez Bob to be stocked, then yes. We can reimburse you directly, usually within a day or two of sending us the receipt. We ask people to order their own special request items to avoid adding on more responsibilities to existing volunteers :).</p>
-                
+
                 <h3>Why don't you stock any "healthy" items?</h3>
-                <p>We have tried in the past to stack "healthy" items like fruits, vegetables, yogurts, etc., but often these items did not sell quickly enough before they went bad. If there's a lot of support for ordering fresher food, we can try it out again and see if the food gets bought in time.</p> 
+                <p>We have tried in the past to stack "healthy" items like fruits, vegetables, yogurts, etc., but often these items did not sell quickly enough before they went bad. If there's a lot of support for ordering fresher food, we can try it out again and see if the food gets bought in time.</p>
 
 
             <h2 id="misc">Misc.</h2>
 
                 <h3>What safety measures are in place to safeguard my account?</h3>
                 <p>Assuming you have set a password on your account (<a href="#set-pw">instructions to set a password here</a>), your password is hashed and salted before being stored in our database. You can also view the full Chez Bob infrastructure source code <a href="https://github.com/chezbob/chezbob/">here</a>.</p>
-                
+
                 <h3>Can we get this ;&ltboard game;&gt for Chez Bob?</h3>
                 <p>Yes, as long as we still have money left in our board game budget! Each academic year, we allocate $100 for buying new board games. Please reach out to us in the #chezbob channel on the CSE Slack, or via email (<a href="mailto:chezbob@cs.ucsd.edu">chezbob@cs.ucsd.edu</a>) to check how much money we have left for the year!</p>
-                
+
                 <h3>Who is Bob?/Why is it named Chez Bob?</h3>
                 <p>Find the answer on our <a href="./history.html">history page</a>!</p>
 
         </div>
       </div>
     </div>
+    <script src="js/font-toggle.js"></script>
   </body>
 </html>

--- a/web/static/history.html
+++ b/web/static/history.html
@@ -455,5 +455,6 @@
       </div>
     </div>
     <script src="js/history.js"></script>
+    <script src="js/font-toggle.js"></script>
   </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -38,5 +38,6 @@
       </div>
     </div>
     <script src="apps/ah/ah-index.js"></script>
+    <script src="js/font-toggle.js"></script>
   </body>
 </html>

--- a/web/static/js/font-toggle.js
+++ b/web/static/js/font-toggle.js
@@ -1,0 +1,22 @@
+const STORAGE_KEY = "chezbob-accessible-font";
+
+const fontToggleButton = document.createElement("button");
+fontToggleButton.id = "font-toggle-btn";
+
+function applyFont(usingAccessibleFont) {
+  document.body.classList.toggle("accessible-font", usingAccessibleFont);
+  fontToggleButton.textContent = usingAccessibleFont ? "Retro Font" : "Accessible Font";
+}
+
+fontToggleButton.addEventListener("click", function () {
+  const toggleAccessibleFont = !document.body.classList.contains("accessible-font");
+  localStorage.setItem(STORAGE_KEY, toggleAccessibleFont ? "1" : "");
+  applyFont(toggleAccessibleFont);
+});
+
+const screen = document.getElementById("screen");
+if (screen) {
+  screen.appendChild(fontToggleButton);
+}
+
+applyFont(Boolean(localStorage.getItem(STORAGE_KEY)));

--- a/web/static/team.html
+++ b/web/static/team.html
@@ -76,5 +76,6 @@
         </div>
       </div>
     </div>
+    <script src="js/font-toggle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #78

Add a button on every front-facing page that
1. toggles a more readable/accessible monospace font and
2. disables the CRT scanline for ease of reading

<img width="2880" height="1624" alt="Regular font, with font toggle button" src="https://github.com/user-attachments/assets/b5c009f5-8936-4a50-b767-1e09b9aedf25" />
<img width="2880" height="1624" alt="More accessible font, with font toggle button" src="https://github.com/user-attachments/assets/a60fe114-b487-4654-8180-0f8a5a2dd9a7" />

