### PR TITLE
Fix dollar display

### DIFF
--- a/web/static/apps/wos/wos.js
+++ b/web/static/apps/wos/wos.js
@@ -38,7 +38,7 @@ async function display_debt() {
   try {
     let debt = await response.json();
     console.log(debt);
-    debt_element.innerHTML = `Total Debt: $${debt.total_debt}`;
+    debt_element.innerHTML = `Total Debt: ${dollars(debt.total_debt, true)}`;
   } catch (e) {
     debt_element.innerHTML = `<div id="message">Total debt can't be displayed today!</div>`;
   }

--- a/web/static/internal/apps/restock/restock.js
+++ b/web/static/internal/apps/restock/restock.js
@@ -1,4 +1,5 @@
 import { ReconnectingSocket } from "/js/reconnecting-socket.js";
+import { dollars } from "/js/money.js";
 
 // Rather than using Modes to control the socket, we put it directly on the window
 // and set up handlers that invoke mode methods like `on_scan`. This keeps us from having
@@ -148,14 +149,8 @@ function calculate_cost_in_cents() {
 
 window.display_cost = () => {
   document.getElementById("cost").innerHTML =
-    "$" + dollars(calculate_cost_in_cents());
+    dollars(calculate_cost_in_cents(), true);
 };
-
-function dollars(cents) {
-  let d = Math.floor(cents / 100);
-  let c = Math.abs(cents) % 100;
-  return `${d}.${c < 10 ? "0" + c : c}`;
-}
 
 async function submit(ev) {
   ev.preventDefault();

--- a/web/static/js/money.js
+++ b/web/static/js/money.js
@@ -10,8 +10,8 @@ export function price_row(item) {
     </div>`;
 }
 
-export function dollars(cents) {
+export function dollars(cents, show_dollar_sign = false) {
   let d = Math.abs(Math.trunc(cents / 100));
   let c = Math.abs(cents) % 100;
-  return `${cents < 0 ? "-" : ""}${d}.${c < 10 ? "0" + c : c}`;
+  return `${cents < 0 ? "-" : ""}${show_dollar_sign ? "$" : ""}${d}.${c < 10 ? "0" + c : c}`;
 }


### PR DESCRIPTION
Add new optional `show_dollar_sign` param to the `dollars` function so that negative dollar amounts can be displayed with the dollar sign in the correct place ("-$1.50", not "$-1.50"). The Wall of Shame currently handles this incorrectly, for example.

<img width="1068" height="98" alt="Wall of Shame showing $-2255.21, with the negative sign after the dollar sign" src="https://github.com/user-attachments/assets/570fb80b-5e8b-4394-b2f7-9eb591526485" />

Also remove duplicate `dollars` function in `restock.js`