### PR TITLE
Fix wrong dollar conversion on WoS

### DIFF
--- a/web/static/apps/wos/wos.js
+++ b/web/static/apps/wos/wos.js
@@ -38,6 +38,7 @@ async function display_debt() {
   try {
     let debt = await response.json();
     console.log(debt);
+    debt.total_debt = debt.total_debt * 100;  // API internally already converts total debt from cents to dollars
     debt_element.innerHTML = `Total Debt: ${dollars(debt.total_debt, true)}`;
   } catch (e) {
     debt_element.innerHTML = `<div id="message">Total debt can't be displayed today!</div>`;

--- a/web/static/js/money.js
+++ b/web/static/js/money.js
@@ -12,6 +12,6 @@ export function price_row(item) {
 
 export function dollars(cents, show_dollar_sign = false) {
   let d = Math.abs(Math.trunc(cents / 100));
-  let c = Math.abs(cents) % 100;
+  let c = Math.abs(Math.round(cents)) % 100;
   return `${cents < 0 ? "-" : ""}${show_dollar_sign ? "$" : ""}${d}.${c < 10 ? "0" + c : c}`;
 }


### PR DESCRIPTION
Fix bug in #124 where the total debt on the WoS is formatted wrong. The WoS API internally already converts the total debt from cents to dollars, so this should be unconverted in order to format it correctly.

Also adds rounding to cents to the `dollar` function to avoid displaying FP errors.
<img width="1754" height="92" alt="image" src="https://github.com/user-attachments/assets/a73d5d8b-83b8-4133-ba7d-47aeab74fac1" />
